### PR TITLE
Fixed bug originating from "syrup" followed by a space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aaronf86-syrupmode",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aaronf86-syrupmode",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "@types/mocha": "^10.0.9",
         "@types/node": "^22.8.4",
@@ -20,7 +20,7 @@
         "ts-loader": "^9.5.1",
         "typescript": "^4.5.5",
         "webpack": "^5.69.0",
-        "webpack-cli": "^4.9.1"
+        "webpack-cli": "^4.10.0"
       },
       "engines": {
         "vscode": "^1.95.0"
@@ -4205,6 +4205,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,13 @@
     "languages": [
       {
         "id": "syrup",
-        "aliases": ["Syrup", "syrup"],
-        "extensions": [".syrup"],
+        "aliases": [
+          "Syrup",
+          "syrup"
+        ],
+        "extensions": [
+          ".syrup"
+        ],
         "configuration": "src/language/syrup-configuration.json"
       }
     ],
@@ -75,7 +80,6 @@
     "ts-loader": "^9.5.1",
     "typescript": "^4.5.5",
     "webpack": "^5.69.0",
-    "webpack-cli": "^4.9.1"
-  },
-  "dependencies": {}
+    "webpack-cli": "^4.10.0"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,7 +82,7 @@ export function activate(context: vscode.ExtensionContext) {
             cancellable: false
         }, (progress) => {
             return new Promise<void>((resolve, reject) => {
-                exec(`syrup -f ${filePath}`, (error, stdout, stderr) => {
+                exec(`syrup -f "${filePath}"`, (error, stdout, stderr) => {
                     if (error) {
                         vscode.window.showErrorMessage(`Error running Syrup script: ${stderr}`);
                         reject(error);


### PR DESCRIPTION
Found a bug where if a user uses the extension in a folder called "syrup playground" for example it would break the extension

Screenshots:
![image](https://github.com/user-attachments/assets/f9ba4310-fda8-45b5-9fa8-e24615d4b403)
![image](https://github.com/user-attachments/assets/7241c7b7-3d9c-4b9c-b5f4-f7170ba2836b)

