### PR TITLE
fix: reuse webview panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to the "syrup-mode" VS Code extension will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,9 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5] - ?
+
+### Added
+
+### Changed
+
+- Changed Webview panel handling so that it is re-used instead created each time `syrup run` is called.
+
+### Fixed
+
+- N/A
+
+## [0.0.4] - ?
+
+## [0.0.3] - ?
+
 ## [0.0.2] - 2024-03-21
 
 ### Added
+
 - Initial release of syrup-mode extension
 - Syntax highlighting support for .syrup files
 - Run command to execute Syrup code
@@ -18,9 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File icon for .syrup files
 
 ### Changed
+
 - N/A
 
 ### Fixed
+
 - N/A
 
 [Unreleased]: https://github.com/AaronF86/VScode-syrupmode/compare/v0.1.0...HEAD

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Syrup language support",
   "icon": "icon/syruplogo.png",
 
-  "version": "0.0.3",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/AaronF86/VScode-syrupmode"


### PR DESCRIPTION
Small change to reuse the web panel instead of creating a new one for every run. Perhaps this could be a configuration option is case some people like a new one created each time for comparison reasons etc? I've made this a `fix` but I guess it could also be classified under `feat`.